### PR TITLE
Bugfix for bullets randomly disappearing prematurely

### DIFF
--- a/Assets/Asteroids/Scripts/GameBehaviour.cs
+++ b/Assets/Asteroids/Scripts/GameBehaviour.cs
@@ -28,6 +28,11 @@ public class GameBehaviour : MonoBehaviour, PoolableAware, Recyclable
         Invoke("RemoveFromGame", time);
     }
 
+    protected virtual void OnDisable()
+    {
+        CancelInvoke("RemoveFromGame");
+    }
+
     public static void KillWithExplosion(GameObject victim)
     {
         Spawn.Explosion(victim.transform.position);

--- a/Assets/Asteroids/Scripts/MicroBehaviours/AsteroidBehaviour.cs
+++ b/Assets/Asteroids/Scripts/MicroBehaviours/AsteroidBehaviour.cs
@@ -29,9 +29,10 @@ public class AsteroidBehaviour : GameBehaviour
         ++activeCount;
     }
 
-    protected virtual void OnDisable()
+    protected override void OnDisable()
     {
         --activeCount;
+        base.OnDisable();
     }
 
     #region Spawning


### PR DESCRIPTION
This was how it was fixed in the earlier design.
- Invoke continues to execute even in a disabled script. It needs to be cancelled.
- The pool is a LIFO stack implementation
- The pool ends up using bullets whose Invoke has yet to execute (if it hit an asteroid and was pooled early, before the bullet's lifetime expiry)
- Hence, they were pooled again prematurely due to the outstanding Invoke.
